### PR TITLE
Instancier la classe image_sizes

### DIFF
--- a/advanced-responsive-images.php
+++ b/advanced-responsive-images.php
@@ -67,4 +67,5 @@ function init_advanced_responsive_images_plugin() {
 	require_once ARI_DIR . 'functions/utils.php';
 	// Client
 	\ARI\Main::get_instance();
+	\ARI\Image_Sizes::get_instance();
 }


### PR DESCRIPTION
SI non instanciée, les images sizes ne sont pas crées dans WP avec add_image_size et donc non utilisables.